### PR TITLE
feat: unix socket connection support

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "url": "git+https://github.com/tmigone/pulseaudio.git"
   },
   "author": "Tomás Migone <tomasmigone@gmail.com>",
+  "contributors": [
+    "SpacingBat3 <npm@spacingbat3.anonaddy.com> (https://github.com/SpacingBat3)"
+  ],
   "license": "MIT",
   "keywords": [
     "pulseaudio",

--- a/src/client.ts
+++ b/src/client.ts
@@ -116,7 +116,11 @@ export default class PulseAudio extends EventEmitter {
   async connect (): Promise<AuthInfo> {
     return await new Promise<AuthInfo>((resolve, reject) => {
       this.socket = new Socket()
-      if (this.address.type === 'tcp') { this.socket.connect(this.address.port, this.address.host) } else { this.socket.connect(this.address.path) }
+      if (this.address.type === 'tcp') {
+        this.socket.connect(this.address.port, this.address.host)
+      } else {
+        this.socket.connect(this.address.path)
+      }
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       this.socket.on('connect', async () => {
         this.connected = true
@@ -124,7 +128,11 @@ export default class PulseAudio extends EventEmitter {
         // Authenticate client
         const reply: AuthInfo = await this.authenticate()
         this.protocol = reply.protocol
-        if (this.address.type === 'tcp') { console.log(`Connected to PulseAudio at tcp://${this.address.host}:${this.address.port} using protocol v${this.protocol}`) } else { console.log(`Connected to PulseAudio at unix://${this.address.path} using protocol v${this.protocol}`) }
+        if (this.address.type === 'tcp') {
+          console.log(`Connected to PulseAudio at tcp://${this.address.host}:${this.address.port} using protocol v${this.protocol}`)
+        } else {
+          console.log(`Connected to PulseAudio at unix://${this.address.path} using protocol v${this.protocol}`)
+        }
 
         if (reply.protocol < PA_PROTOCOL_MINIMUM_VERSION) {
           this.disconnect()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import PulseAudio, { TCPSocket } from './client'
+import PulseAudio, { TCPSocket, UnixSocket } from './client'
 import {
   AuthInfo,
   ChannelVolume,
@@ -36,6 +36,7 @@ export {
   VolumeInfo
 }
 
-export {
-  TCPSocket
+export type {
+  TCPSocket,
+  UnixSocket
 }

--- a/test/unit/client.spec.ts
+++ b/test/unit/client.spec.ts
@@ -4,6 +4,7 @@ import PulseAudio from '../../src/client'
 test('PAClient.parseAdress: "tcp:host:port" address parsed correctly', t => {
   const client: PulseAudio = new PulseAudio('tcp:localhost:1234')
   t.deepEqual(client.address, {
+    type: 'tcp',
     host: 'localhost',
     port: 1234
   })
@@ -12,21 +13,24 @@ test('PAClient.parseAdress: "tcp:host:port" address parsed correctly', t => {
 test('PAClient.parseAdress: "tcp:host" address parsed correctly', t => {
   const client: PulseAudio = new PulseAudio('tcp:localhost')
   t.deepEqual(client.address, {
+    type: 'tcp',
     host: 'localhost',
     port: 4317
   })
 })
 
-// test('PAClient.parseAdress: "unix:/path/to/socket" address parsed correctly', t => {
-//   const client: PAClient = new PAClient('unix:/run/pulse/pulseaudio.socket')
-//   t.deepEqual(client.pulseAddress, {
-//     path: '/run/pulse/pulseaudio.socket'
-//   })
-// })
+test('PAClient.parseAdress: "unix:/path/to/socket" address parsed correctly', t => {
+  const client: PulseAudio = new PulseAudio('unix:/run/pulse/pulseaudio.socket')
+  t.deepEqual(client.address, {
+    type: 'unix',
+    path: '/run/pulse/pulseaudio.socket'
+  })
+})
 
 test('PAClient.parseAdress: "host:port" address parsed correctly', t => {
   const client: PulseAudio = new PulseAudio('localhost:1111')
   t.deepEqual(client.address, {
+    type: 'tcp',
     host: 'localhost',
     port: 1111
   })


### PR DESCRIPTION
This Pull Request aims to bring support to `unix:` addresses and brings minior improvements to address parsing in general. While I've tried to make this PR match the author's code style, I may also improve it a bit to replace bunch of `if` statements with `switch ... case` – but I thought that would be outside of the scope for this PR right now.

This Pull Request resolves #32.