### PR TITLE
fix #39: `getSink` / `getSource` always return empty port list

### DIFF
--- a/src/commands/sink/index.ts
+++ b/src/commands/sink/index.ts
@@ -46,7 +46,7 @@ export const parseSinkPacket = (packet: PAPacket, protocol: number): Sink[] => {
         name: tags.nextValue(),
         description: tags.nextValue(),
         priority: tags.nextValue(),
-        availabe: tags.nextValue()
+        available: tags.nextValue()
       }
 
       // PulseAudio >= v14.0
@@ -54,6 +54,8 @@ export const parseSinkPacket = (packet: PAPacket, protocol: number): Sink[] => {
         port.availabilityGroup = tags.nextValue()
         port.type = tags.nextValue()
       }
+
+      sink.ports.push(port)
     }
 
     sink.activePortName = tags.nextValue()

--- a/src/commands/source/index.ts
+++ b/src/commands/source/index.ts
@@ -46,7 +46,7 @@ export const parseSourcePacket = (packet: PAPacket, protocol: number): Source[] 
         name: tags.nextValue(),
         description: tags.nextValue(),
         priority: tags.nextValue(),
-        availabe: tags.nextValue()
+        available: tags.nextValue()
       }
 
       // PulseAudio >= v14.0
@@ -54,6 +54,8 @@ export const parseSourcePacket = (packet: PAPacket, protocol: number): Source[] 
         port.availabilityGroup = tags.nextValue()
         port.type = tags.nextValue()
       }
+
+      source.ports.push(port)
     }
 
     source.activePortName = tags.nextValue()

--- a/src/types/pulseaudio.ts
+++ b/src/types/pulseaudio.ts
@@ -40,7 +40,7 @@ export interface Port {
   name: string
   description: string
   priority: number
-  availabe?: boolean
+  available?: boolean
   availabilityGroup?: string
   type?: number
 }

--- a/test/unit/fixtures/sink/getSink.json
+++ b/test/unit/fixtures/sink/getSink.json
@@ -57,7 +57,14 @@
     "volumeSteps": 65537,
     "cardIndex": 0,
     "numberPorts": 1,
-    "ports": [],
+    "ports": [
+      {
+        "available": 0,
+        "description": "Headphones",
+        "name": "analog-output-headphones",
+        "priority": 9900
+      }
+    ],
     "activePortName": "analog-output-headphones",
     "formats": [{ "encoding": 1, "properties": [] }]
   }

--- a/test/unit/fixtures/sink/getSinkList.json
+++ b/test/unit/fixtures/sink/getSinkList.json
@@ -58,7 +58,14 @@
       "volumeSteps": 65537,
       "cardIndex": 0,
       "numberPorts": 1,
-      "ports": [],
+      "ports": [
+        {
+          "available": 0,
+          "description": "Headphones",
+          "name": "analog-output-headphones",
+          "priority": 9900
+        }
+      ],
       "activePortName": "analog-output-headphones",
       "formats": [{ "encoding": 1, "properties": [] }]
     }


### PR DESCRIPTION
Easy enough, so I fixed it myself. I also took the liberty of fixing a typo in a field name that presumably won't have come up since no port objects have ever crossed the API boundary before.