### PR TITLE
fix: processing PAPacket hangs if no tags returned from PA server

### DIFF
--- a/src/utils/iterator.ts
+++ b/src/utils/iterator.ts
@@ -17,7 +17,7 @@ export function createIterator (array: any[]): Iterator<any> {
       if (++this.index === this.length) this.done = true
       return iterator.next().value
     },
-    done: false,
+    done: array.length === 0,
     index: 0,
     length: array.length
   }


### PR DESCRIPTION
### Description

If PAServer response has no sink inputs calling `await client.getSinkInputList()` goes to infinite loop at `parseSinkInputPacket` because tags iterable never dones